### PR TITLE
Refactor push command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,8 @@ jobs:
         pip install .
     - name: Format with black
       run: |
+        black --version
+        black --diff whatsopt
         black --check whatsopt
     - name: Test with pytest
       run: |

--- a/tests/test_wop.py
+++ b/tests/test_wop.py
@@ -12,7 +12,7 @@ def file(name):
 
 COMMANDS = [
     "wop push -n {}".format(file("sellar.py")),
-    "wop push -x -n {}".format(file("sellar.py")),
+    "wop push --old -n {}".format(file("sellar.py")),
     "wop upload -n -a 1 {}".format(file("run_parameters_init.py")),
     "wop upload -n {}".format(file("test_doe.csv")),
     "wop upload -n {}".format(file("test_doe.sqlite")),
@@ -36,8 +36,9 @@ class TestWopCommand(unittest.TestCase):
     def test_push_depth(self):
         self.maxDiff = None
         for d in range(3):
+            print(f"DEPTH={d}")
             out = self._test_wop_cmd(
-                "wop push -d {} -n {}".format(
+                "wop push --old -d {} -n {}".format(
                     d, file("multipoint_beam/multipoint_beam_group.py")
                 )
             )

--- a/whatsopt/push_utils.py
+++ b/whatsopt/push_utils.py
@@ -164,3 +164,12 @@ pb.final_setup()
         yield pbfile
     finally:
         os.unlink(pbfile)
+
+
+def find_indep_var_name(pb, absname):
+    target = None
+    for tgt, src in pb.model._conn_global_abs_in2out.items():
+        if src == absname:
+            target = tgt
+            break
+    return pb.model._var_abs2prom["input"].get(target)

--- a/whatsopt/wop.py
+++ b/whatsopt/wop.py
@@ -74,11 +74,7 @@ def status(ctx):
     help="manage (1,) shape variables as scalar variables",
 )
 @click.option(
-    "-x",
-    "--experimental",
-    is_flag=True,
-    default=False,
-    help="use experimental push dealing with connect calls and unpromoted variables",
+    "--old", is_flag=True, default=False, help="use old push",
 )
 @click.option("--name", help="find analysis with given name")
 @click.option(
@@ -100,14 +96,14 @@ def status(ctx):
 )
 @click.argument("filename")
 @click.pass_context
-def push(ctx, dry_run, scalar, experimental, name, component, depth, json, filename):
+def push(ctx, dry_run, scalar, old, name, component, depth, json, filename):
     """Push OpenMDAO problem or WhatsOpt analysis json from given FILENAME"""
     ctx.obj["login"] = not dry_run
     wop = WhatsOpt(**ctx.obj)
     options = {
         "--dry-run": dry_run,
         "--scalar": scalar,
-        "--experimental": experimental,
+        "--old": old,
         "--name": name,
         "--depth": depth,
     }

--- a/whatsopt/wop.py
+++ b/whatsopt/wop.py
@@ -74,7 +74,10 @@ def status(ctx):
     help="manage (1,) shape variables as scalar variables",
 )
 @click.option(
-    "--old", is_flag=True, default=False, help="use old push",
+    "--old",
+    is_flag=True,
+    default=False,
+    help="use old push",
 )
 @click.option("--name", help="find analysis with given name")
 @click.option(


### PR DESCRIPTION
This PR refactors push command:
* use auto_ivc components to retrieve independant variables
* switch push implementations:
   - default becomes `old`: `wop push --old <openmdao_problem.py>`
   - `experimental` becomes default: `-x/ --experimental` removed

This PR prepares the removal of IndepVarComp generation. See https://github.com/OneraHub/WhatsOpt/issues/59