### PR TITLE
Fix push wrt OM 3.10 value-to-val renaming

### DIFF
--- a/whatsopt/push_command.py
+++ b/whatsopt/push_command.py
@@ -286,7 +286,8 @@ class PushCommand(object):
                 meta = system._var_abs2meta[io][abs_name]
 
                 vtype = "Float"
-                if re.match("int", type(meta["value"]).__name__):
+                val = meta.get("value", meta.get("val"))  # fix OpenMDAO < 3.10
+                if re.match("int", type(val).__name__):
                     vtype = "Integer"
                 shape = str(meta["shape"])
                 shape = format_shape(self.scalar, shape)
@@ -300,7 +301,7 @@ class PushCommand(object):
                     "shape": shape,
                     "units": meta["units"],
                     #'desc': meta['desc'],
-                    "value": meta["value"],
+                    "value": val,
                 }
 
                 # retrieve initial conditions

--- a/whatsopt/push_utils.py
+++ b/whatsopt/push_utils.py
@@ -132,7 +132,7 @@ inputs = comp.list_inputs(out_stream=None)
 indeps = IndepVarComp()
 for name, meta in inputs:
     args = {{
-        "val": meta.get("value"),
+        "val": meta.get("value", meta.get("val")),   # fix OpenMDAO < 3.10
         "shape": meta.get("shape"),
         "desc": meta.get("desc", ""),
         "units": meta.get("units", None)

--- a/whatsopt/universal_push_command.py
+++ b/whatsopt/universal_push_command.py
@@ -315,7 +315,8 @@ class UniversalPushCommand(object):
                 meta = system._var_abs2meta[io][abs_name]
 
                 vtype = "Float"
-                if re.match("int", type(meta["value"]).__name__):
+                val = meta.get("value", meta.get("val"))  # fix OpenMDAO < 3.10
+                if re.match("int", type(val).__name__):
                     vtype = "Integer"
                 shape = str(meta["shape"])
                 shape = format_shape(self.scalar, shape)
@@ -328,7 +329,7 @@ class UniversalPushCommand(object):
                     "type": vtype,
                     "shape": shape,
                     "units": meta["units"],
-                    "value": meta["value"],
+                    "value": val,
                 }
 
                 # retrieve initial conditions


### PR DESCRIPTION
With OpenMDAO 3.10, `value` key in meta dict is renamed val. This PR fixes push to take into account this change while keeping compatibility with OpenMDAO < 3.10.